### PR TITLE
feat(generative): speed up token streaming, avoid useStreamableValue if only last value is needed

### DIFF
--- a/app/generative_ui/ai/message.tsx
+++ b/app/generative_ui/ai/message.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { StreamableValue, useStreamableValue } from "ai/rsc";
+
+export function AIMessage(props: { value: StreamableValue<string> }) {
+  const [data] = useStreamableValue(props.value);
+
+  return (
+    <div className="empty:hidden border border-gray-700 p-3 rounded-lg max-w-[50vw]">
+      {data}
+    </div>
+  );
+}

--- a/app/generative_ui/page.tsx
+++ b/app/generative_ui/page.tsx
@@ -4,7 +4,6 @@ import { useState } from "react";
 import type { EndpointsContext } from "./agent";
 import { useActions } from "./utils/client";
 import { LocalContext } from "./shared";
-import { readStreamableValue } from "ai/rsc";
 
 export default function GenerativeUIPage() {
   const actions = useActions<typeof EndpointsContext>();
@@ -35,16 +34,12 @@ export default function GenerativeUIPage() {
     // consume the value stream to obtain the final string value
     // after which we can append to our chat history state
     (async () => {
-      let finalValue: string | null = null;
-      for await (const value of readStreamableValue(element.value)) {
-        finalValue = value;
-      }
-
-      if (finalValue != null) {
+      let lastEvent = await element.lastEvent;
+      if (typeof lastEvent === "string") {
         setHistory((prev) => [
           ...prev,
           ["user", input],
-          ["assistant", finalValue as string],
+          ["assistant", lastEvent],
         ]);
       }
     })();


### PR DESCRIPTION
Relying on `useStreamableUI` for high-speed updates doesn't work well in practice, as the rendering updates are being batched, most likely by React itself rather than in AI SDK. 

To overcome this, we instead send a "generator" to the client via `createStreamableValue` and render the intermediate values ourselves via `useStreamableValue`