### PR TITLE
docs: add Deploy to PandaStack button

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/langchain-ai/langchain-nextjs-template)
 [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Flangchain-ai%2Flangchain-nextjs-template)
+[![Deploy to PandaStack](https://dashboard.pandastack.io/deploy-button.svg)](https://dashboard.pandastack.io/deploy?repo=langchain-ai/langchain-nextjs-template&type=container&env=OPENAI_API_KEY,LANGCHAIN_CALLBACKS_BACKGROUND&envDescription=https://github.com/langchain-ai/langchain-nextjs-template/blob/main/.env.example)
 
 This template scaffolds a LangChain.js + Next.js starter app. It showcases how to use and combine LangChain modules for several
 use cases. Specifically:


### PR DESCRIPTION
## What this does

Adds a **Deploy to PandaStack** button to the README, alongside the existing deploy options.

[PandaStack](https://pandastack.io) is a deployment platform (like Railway/Render). It auto-detects the framework and runs the app — one click, no config. This PR only adds a README badge; no code or workflow changes.

If you'd prefer not to include it, feel free to close — no worries either way. Thanks for the great project! 🙌