### PR TITLE
chore: add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary

- add weekly Dependabot updates for root Yarn/npm dependencies
- add weekly Dependabot updates for GitHub Actions

## Validation

- parsed `.github/dependabot.yml` with Ruby's YAML parser
- ran `git diff --check`
- confirmed the change is limited to `.github/dependabot.yml`
