### PR TITLE
security: bump ip-address and nanoid

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4723,9 +4723,9 @@ __metadata:
   linkType: hard
 
 "ip-address@npm:^10.1.1":
-  version: 10.2.0
-  resolution: "ip-address@npm:10.2.0"
-  checksum: 3ffba04dc4cdaf81ed2ed6edc47eee1494bb97550ef73f1918ca28405d175c03efa416b8337e868123b08c2cc677e3a07c5ce03eda3b1aeb2741c149bd37ddf9
+  version: 10.5.0
+  resolution: "ip-address@npm:10.5.0"
+  checksum: ffb64aea3ab0bf975b237954f89bf3c37cb5fc9d078cf5868408e54d29636d14618ed67dafcde664b3cdfc778ee78c811286cf67e59d1243a0c198d05aa47683
   languageName: node
   linkType: hard
 
@@ -5714,11 +5714,11 @@ __metadata:
   linkType: hard
 
 "nanoid@npm:^3.3.8":
-  version: 3.3.11
-  resolution: "nanoid@npm:3.3.11"
+  version: 3.3.18
+  resolution: "nanoid@npm:3.3.18"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: 3be20d8866a57a6b6d218e82549711c8352ed969f9ab3c45379da28f405363ad4c9aeb0b39e9abc101a529ca65a72ff9502b00bf74a912c4b64a9d62dfd26c29
+  checksum: db804317d337b41602666f23014e399d1263033d13a903955c246378256fd4e002519e87199ca40b19aff52274965ac7cc6e70c13a63e194e15c4664724602d3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- bump `ip-address` from 10.2.0 to 10.5.0
- bump `nanoid` from 3.3.11 to 3.3.18
- keep the change scoped to `yarn.lock`

This replaces the failed Dependabot grouped security update and resolves the vulnerable versions tracked by Dependabot alerts #105, #106, #108, #110, and #112.

## Validation

- `corepack yarn install --immutable` (passed with existing peer-dependency warnings)
- `git diff --check`
- verified resolved versions against each advisory's vulnerable range and first patched version