### PR TITLE
feat: add OrcaRouter as a configurable OpenAI-compatible gateway provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,14 @@
 OPENAI_API_KEY="YOUR_API_KEY"
 LANGCHAIN_CALLBACKS_BACKGROUND=false
 
+# Optional: Route all examples through OrcaRouter (OpenAI-compatible gateway).
+# When ORCAROUTER_API_KEY is set, every example uses the OrcaRouter gateway
+# instead of the OpenAI API directly (get an API key at https://www.orcarouter.ai).
+# ORCAROUTER_API_KEY="sk-orca-..."
+# ORCAROUTER_BASE_URL="https://api.orcarouter.ai/v1"
+# ORCAROUTER_MODEL="orcarouter/auto"
+# ORCAROUTER_EMBEDDING_MODEL="openai/text-embedding-3-small"
+
 # Required for agent example
 # SERPAPI_API_KEY="YOUR_API_KEY"
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ You can check out a hosted version of this repo here: https://langchain-nextjs-t
 First, clone this repo and download it locally.
 
 Next, you'll need to set up environment variables in your repo's `.env.local` file. Copy the `.env.example` file to `.env.local`.
-To start with the basic examples, you'll just need to add your OpenAI API key.
+To start with the basic examples, you'll just need to add your OpenAI API key — or an `ORCAROUTER_API_KEY` to route everything through the [OrcaRouter](#-orcarouter) gateway instead.
 
 Because this app is made to run in serverless Edge functions, make sure you've set the `LANGCHAIN_CALLBACKS_BACKGROUND` environment variable to `false` to ensure tracing finishes if you are using [LangSmith tracing](https://docs.smith.langchain.com/).
 
@@ -58,6 +58,19 @@ The chain in this example uses a [popular library called Zod](https://zod.dev) t
 It then passes that schema as a function into OpenAI and passes a `function_call` parameter to force OpenAI to return arguments in the specified format.
 
 For more details, [check out this documentation page](https://js.langchain.com/docs/how_to/structured_output).
+
+## 🐋 OrcaRouter
+
+Every example can be pointed at [OrcaRouter](https://www.orcarouter.ai), an OpenAI-compatible AI gateway, by setting `ORCAROUTER_API_KEY` in `.env.local`. When set, all chat models and embeddings in this template route through the OrcaRouter gateway (`https://api.orcarouter.ai/v1`) instead of the OpenAI API directly, with zero code changes to the examples. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.
+
+```bash
+cp .env.example .env.local
+# Set your key, then:
+export ORCAROUTER_API_KEY="sk-orca-..."
+yarn dev
+```
+
+Chat defaults to the adaptive `orcarouter/auto` model; embeddings default to `openai/text-embedding-3-small`. Both are configurable via `ORCAROUTER_MODEL`, `ORCAROUTER_EMBEDDING_MODEL`, and `ORCAROUTER_BASE_URL`. Without `ORCAROUTER_API_KEY`, the examples keep using OpenAI exactly as before.
 
 ## 🦜 Agents
 

--- a/app/ai_sdk/agent/action.ts
+++ b/app/ai_sdk/agent/action.ts
@@ -1,6 +1,5 @@
 "use server";
 
-import { ChatOpenAI } from "@langchain/openai";
 import { ChatPromptTemplate } from "@langchain/core/prompts";
 import { TavilySearch } from "@langchain/tavily";
 import {
@@ -9,6 +8,8 @@ import {
 } from "@langchain/classic/agents";
 import { pull } from "@langchain/classic/hub";
 import { createStreamableValue } from "@ai-sdk/rsc";
+
+import { getChatModel } from "@/lib/llm";
 
 export async function runAgent(input: string) {
   "use server";
@@ -20,7 +21,7 @@ export async function runAgent(input: string) {
       "hwchase17/openai-tools-agent",
     );
 
-    const llm = new ChatOpenAI({ model: "gpt-4o-mini", temperature: 0 });
+    const llm = getChatModel({ temperature: 0 });
 
     const agent = createToolCallingAgent({
       llm,

--- a/app/ai_sdk/tools/action.ts
+++ b/app/ai_sdk/tools/action.ts
@@ -1,12 +1,13 @@
 "use server";
 
-import { ChatOpenAI } from "@langchain/openai";
 import { ChatPromptTemplate } from "@langchain/core/prompts";
 import { createStreamableValue } from "@ai-sdk/rsc";
 import { z } from "zod";
 import { Runnable } from "@langchain/core/runnables";
 import { zodToJsonSchema } from "zod-to-json-schema";
 import { JsonOutputKeyToolsParser } from "@langchain/core/output_parsers/openai_tools";
+
+import { getChatModel } from "@/lib/llm";
 
 const Weather = z
   .object({
@@ -35,10 +36,7 @@ export async function executeTool(
       ["human", "{input}"],
     ]);
 
-    const llm = new ChatOpenAI({
-      model: "gpt-4o-mini",
-      temperature: 0,
-    });
+    const llm = getChatModel({ temperature: 0 });
 
     let chain: Runnable;
 

--- a/app/api/chat/agents/route.ts
+++ b/app/api/chat/agents/route.ts
@@ -2,7 +2,6 @@ import { NextRequest, NextResponse } from "next/server";
 import { type UIMessage, type TextUIPart, createTextStreamResponse } from "ai";
 
 import { createReactAgent } from "@langchain/langgraph/prebuilt";
-import { ChatOpenAI } from "@langchain/openai";
 import { SerpAPI } from "@langchain/community/tools/serpapi";
 import { Calculator } from "@langchain/community/tools/calculator";
 import {
@@ -12,6 +11,8 @@ import {
   HumanMessage,
   SystemMessage,
 } from "@langchain/core/messages";
+
+import { getChatModel } from "@/lib/llm";
 
 export const runtime = "edge";
 
@@ -71,10 +72,7 @@ export async function POST(req: NextRequest) {
     // Requires process.env.SERPAPI_API_KEY to be set: https://serpapi.com/
     // You can remove this or use a different tool instead.
     const tools = [new Calculator(), new SerpAPI()];
-    const chat = new ChatOpenAI({
-      model: "gpt-4o-mini",
-      temperature: 0,
-    });
+    const chat = getChatModel({ temperature: 0 });
 
     /**
      * Use a prebuilt LangGraph agent.

--- a/app/api/chat/retrieval/route.ts
+++ b/app/api/chat/retrieval/route.ts
@@ -3,7 +3,6 @@ import { type UIMessage, type TextUIPart, createTextStreamResponse } from "ai";
 
 import { createClient } from "@supabase/supabase-js";
 
-import { ChatOpenAI, OpenAIEmbeddings } from "@langchain/openai";
 import { PromptTemplate } from "@langchain/core/prompts";
 import { SupabaseVectorStore } from "@langchain/community/vectorstores/supabase";
 import { Document } from "@langchain/core/documents";
@@ -12,6 +11,8 @@ import {
   BytesOutputParser,
   StringOutputParser,
 } from "@langchain/core/output_parsers";
+
+import { getChatModel, getEmbeddings } from "@/lib/llm";
 
 export const runtime = "edge";
 
@@ -80,16 +81,13 @@ export async function POST(req: NextRequest) {
     const previousMessages = messages.slice(0, -1);
     const currentMessageContent = getMessageText(messages[messages.length - 1]);
 
-    const model = new ChatOpenAI({
-      model: "gpt-4o-mini",
-      temperature: 0.2,
-    });
+    const model = getChatModel({ temperature: 0.2 });
 
     const client = createClient(
       process.env.SUPABASE_URL!,
       process.env.SUPABASE_PRIVATE_KEY!,
     );
-    const vectorstore = new SupabaseVectorStore(new OpenAIEmbeddings(), {
+    const vectorstore = new SupabaseVectorStore(getEmbeddings(), {
       client,
       tableName: "documents",
       queryName: "match_documents",

--- a/app/api/chat/retrieval_agents/route.ts
+++ b/app/api/chat/retrieval_agents/route.ts
@@ -11,9 +11,10 @@ import {
   HumanMessage,
   SystemMessage,
 } from "@langchain/core/messages";
-import { ChatOpenAI, OpenAIEmbeddings } from "@langchain/openai";
 import { createRetrieverTool } from "@langchain/classic/tools/retriever";
 import { createReactAgent } from "@langchain/langgraph/prebuilt";
+
+import { getChatModel, getEmbeddings } from "@/lib/llm";
 
 export const runtime = "edge";
 
@@ -73,16 +74,13 @@ export async function POST(req: NextRequest) {
       .map(convertVercelMessageToLangChainMessage);
     const returnIntermediateSteps = body.show_intermediate_steps;
 
-    const chatModel = new ChatOpenAI({
-      model: "gpt-4o-mini",
-      temperature: 0.2,
-    });
+    const chatModel = getChatModel({ temperature: 0.2 });
 
     const client = createClient(
       process.env.SUPABASE_URL!,
       process.env.SUPABASE_PRIVATE_KEY!,
     );
-    const vectorstore = new SupabaseVectorStore(new OpenAIEmbeddings(), {
+    const vectorstore = new SupabaseVectorStore(getEmbeddings(), {
       client,
       tableName: "documents",
       queryName: "match_documents",

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,9 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { type UIMessage, type TextUIPart, createTextStreamResponse } from "ai";
 
-import { ChatOpenAI } from "@langchain/openai";
 import { PromptTemplate } from "@langchain/core/prompts";
 import { HttpResponseOutputParser } from "@langchain/classic/output_parsers";
+
+import { getChatModel } from "@/lib/llm";
 
 export const runtime = "edge";
 
@@ -48,10 +49,7 @@ export async function POST(req: NextRequest) {
      * See a full list of supported models at:
      * https://js.langchain.com/docs/modules/model_io/models/
      */
-    const model = new ChatOpenAI({
-      temperature: 0.8,
-      model: "gpt-4o-mini",
-    });
+    const model = getChatModel({ temperature: 0.8 });
 
     /**
      * Chat models stream message chunks rather than bytes, so this

--- a/app/api/chat/structured_output/route.ts
+++ b/app/api/chat/structured_output/route.ts
@@ -2,8 +2,9 @@ import { NextRequest, NextResponse } from "next/server";
 
 import { z } from "zod";
 
-import { ChatOpenAI } from "@langchain/openai";
 import { PromptTemplate } from "@langchain/core/prompts";
+
+import { getChatModel } from "@/lib/llm";
 
 export const runtime = "edge";
 
@@ -29,12 +30,11 @@ export async function POST(req: NextRequest) {
 
     const prompt = PromptTemplate.fromTemplate(TEMPLATE);
     /**
-     * Function calling is currently only supported with ChatOpenAI models
+     * Function calling is currently only supported with ChatOpenAI models.
+     * `getChatModel` returns a ChatOpenAI-compatible model configured for
+     * OrcaRouter when `ORCAROUTER_API_KEY` is set.
      */
-    const model = new ChatOpenAI({
-      temperature: 0.8,
-      model: "gpt-4o-mini",
-    });
+    const model = getChatModel({ temperature: 0.8 });
 
     /**
      * We use Zod (https://zod.dev) to define our schema for convenience,

--- a/app/api/retrieval/ingest/route.ts
+++ b/app/api/retrieval/ingest/route.ts
@@ -3,7 +3,8 @@ import { RecursiveCharacterTextSplitter } from "@langchain/textsplitters";
 
 import { createClient } from "@supabase/supabase-js";
 import { SupabaseVectorStore } from "@langchain/community/vectorstores/supabase";
-import { OpenAIEmbeddings } from "@langchain/openai";
+
+import { getEmbeddings } from "@/lib/llm";
 
 export const runtime = "edge";
 
@@ -48,7 +49,7 @@ export async function POST(req: NextRequest) {
 
     const vectorstore = await SupabaseVectorStore.fromDocuments(
       splitDocuments,
-      new OpenAIEmbeddings(),
+      getEmbeddings(),
       {
         client,
         tableName: "documents",

--- a/app/langgraph/agent/agent.ts
+++ b/app/langgraph/agent/agent.ts
@@ -4,9 +4,10 @@ import {
   START,
   Annotation,
 } from "@langchain/langgraph";
-import { ChatOpenAI } from "@langchain/openai";
 
-const llm = new ChatOpenAI({ model: "gpt-4o-mini", temperature: 0 });
+import { getChatModel } from "@/lib/llm";
+
+const llm = getChatModel({ temperature: 0 });
 
 const builder = new StateGraph(
   Annotation.Root({

--- a/lib/llm.ts
+++ b/lib/llm.ts
@@ -1,0 +1,60 @@
+import { ChatOpenAI, OpenAIEmbeddings } from "@langchain/openai";
+
+/**
+ * Shared LLM factory for the starter app.
+ *
+ * When `ORCAROUTER_API_KEY` is set, every example routes through the
+ * [OrcaRouter](https://www.orcarouter.ai) gateway (OpenAI-compatible) instead
+ * of the OpenAI API directly:
+ *
+ * - Chat models use `orcarouter/auto` (adaptive routing) against
+ *   `https://api.orcarouter.ai/v1` by default, overridable via
+ *   `ORCAROUTER_MODEL` / `ORCAROUTER_BASE_URL`.
+ * - Embeddings use `openai/text-embedding-3-small` via the same gateway,
+ *   overridable via `ORCAROUTER_EMBEDDING_MODEL`.
+ *
+ * Without `ORCAROUTER_API_KEY` the factory behaves exactly as before
+ * (`gpt-4o-mini` chat + default OpenAI embeddings).
+ */
+const ORCAROUTER_BASE_URL = "https://api.orcarouter.ai/v1";
+const ORCAROUTER_CHAT_MODEL = "orcarouter/auto";
+const ORCAROUTER_EMBEDDING_MODEL = "openai/text-embedding-3-small";
+
+export function getChatModel(options?: {
+  temperature?: number;
+  model?: string;
+}) {
+  const temperature = options?.temperature ?? 0;
+
+  if (process.env.ORCAROUTER_API_KEY) {
+    return new ChatOpenAI({
+      model:
+        options?.model ?? process.env.ORCAROUTER_MODEL ?? ORCAROUTER_CHAT_MODEL,
+      temperature,
+      configuration: {
+        baseURL: process.env.ORCAROUTER_BASE_URL ?? ORCAROUTER_BASE_URL,
+        apiKey: process.env.ORCAROUTER_API_KEY,
+      },
+    });
+  }
+
+  return new ChatOpenAI({
+    model: options?.model ?? process.env.OPENAI_MODEL ?? "gpt-4o-mini",
+    temperature,
+  });
+}
+
+export function getEmbeddings() {
+  if (process.env.ORCAROUTER_API_KEY) {
+    return new OpenAIEmbeddings({
+      model:
+        process.env.ORCAROUTER_EMBEDDING_MODEL ?? ORCAROUTER_EMBEDDING_MODEL,
+      configuration: {
+        baseURL: process.env.ORCAROUTER_BASE_URL ?? ORCAROUTER_BASE_URL,
+        apiKey: process.env.ORCAROUTER_API_KEY,
+      },
+    });
+  }
+
+  return new OpenAIEmbeddings();
+}


### PR DESCRIPTION
## What changed

Add [OrcaRouter](https://www.orcarouter.ai) as a configurable, OpenAI-compatible gateway provider for every example in this template.

A new shared factory `lib/llm.ts` (`getChatModel` / `getEmbeddings`) now constructs the chat model and embeddings used across all routes and pages:

- When `ORCAROUTER_API_KEY` is set, chat models point at the OrcaRouter gateway (`https://api.orcarouter.ai/v1`) with the adaptive `orcarouter/auto` model, and embeddings use `openai/text-embedding-3-small` through the same gateway. `ORCAROUTER_MODEL`, `ORCAROUTER_EMBEDDING_MODEL`, and `ORCAROUTER_BASE_URL` provide overrides.
- Without the key, behavior is unchanged (`gpt-4o-mini` + default OpenAI embeddings).

Call sites updated (no behavior change when `ORCAROUTER_API_KEY` is unset):

- `app/api/chat/route.ts`
- `app/api/chat/retrieval/route.ts`
- `app/api/chat/agents/route.ts`
- `app/api/chat/retrieval_agents/route.ts`
- `app/api/chat/structured_output/route.ts`
- `app/api/retrieval/ingest/route.ts`
- `app/langgraph/agent/agent.ts`
- `app/ai_sdk/agent/action.ts`
- `app/ai_sdk/tools/action.ts`

Docs: `.env.example` documents the new variables; `README.md` gains an "OrcaRouter" section. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## How verified

- `yarn lint` — clean (0 errors)
- `npx tsc --noEmit` — clean
- `yarn build` — full Next.js production build succeeds, all routes compile
- `npx prettier --check` — clean
- Live test with a real `ORCAROUTER_API_KEY`: chat invoke through `getChatModel` returned a response from `https://api.orcarouter.ai/v1`; `getEmbeddings` returned a 1536-dim embedding; `withStructuredOutput` returned valid JSON — all through the new provider path.

Disclosure: I'm an engineer on the OrcaRouter team.
